### PR TITLE
Update CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode9.3beta
 notifications:
   email: false
-rvm: 2.3
 script:
 - set -o pipefail
 - xcodebuild -workspace Example/SuperMessagingProxyTests.xcworkspace -scheme OSXObjcTests -destination "platform=OS X,arch=x86_64" test | xcpretty


### PR DESCRIPTION
This PR updates the config with Xcode 9.3 beta to fix build errors. Since `xcpretty` is pre-installed on the recent VMs, it seems okay to run the tests without specifying the Ruby version.